### PR TITLE
Xcode16 Expression fix

### DIFF
--- a/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
+++ b/Sources/ApolloSQLite/SQLiteNormalizedCache.swift
@@ -14,9 +14,9 @@ public final class SQLiteNormalizedCache {
 
   private let db: Connection
   private let records = Table("records")
-  private let id = Expression<Int64>("_id")
-  private let key = Expression<CacheKey>("key")
-  private let record = Expression<String>("record")
+  private let id = SQLite.Expression<Int64>("_id")
+  private let key = SQLite.Expression<CacheKey>("key")
+  private let record = SQLite.Expression<String>("record")
   private let shouldVacuumOnClear: Bool
 
   /// Designated initializer


### PR DESCRIPTION
Making the changes for namespace conflict with Swift.Expression, should be using SQLite.Expression https://github.com/stephencelis/SQLite.swift/issues/1277